### PR TITLE
Fix requestAnimationFrame spam/freeze-up from depth overflow

### DIFF
--- a/Echelon/Profile Folder/chrome/JS/echelon_utils.uc.js
+++ b/Echelon/Profile Folder/chrome/JS/echelon_utils.uc.js
@@ -49,12 +49,17 @@ function renderElement(nodeName, attrMap = {}, childrenArr = [])
 	return element;
 }
 
-async function waitForElement(query, parent = this.document, timeout = -1)
+async function waitForElement(query, parent = this.document, timeout = 10000)
 {
 	let startTime = Date.now();
 	
 	while (parent.querySelector(query) == null)
 	{
+		// XXX(isabella): Be very careful with disabling the timeout. If requestAnimationFrame is called too
+		// deeply, then the entire requestAnimationFrame function will be broken globally across the entire
+		// window. The maximum depth that it can attain is the signed 32-bit integer maximum (2,147,483,647)
+		//
+		// https://github.com/mozilla-firefox/firefox/blob/5cc1a7909a4e4abb7db47926c88c2d173158e9d2/dom/base/RequestCallbackManager.h#L47-L50
 		if (timeout > -1 && Date.now > startTime + timeout)
 		{
 			return null;


### PR DESCRIPTION
This commit fixes an error I was encountering on my local configuration with long-living browser windows.

The problem is that a forever-running waitForElement call may result in its requestAnimationFrame calls nesting past the 32-bit signed integer maximum, at which point requestAnimationFrame will break for the document (in this case, the document is the browser window itself, and cannot be navigated away from) forever, doomed to return NS_ERROR_NOT_AVAILABLE.

I changed the default timeout behaviour from disabled to 10 seconds, which is more than enough time for most elements to appear. Quite frankly, if any code was written to wait for rare elements to be created using this method, then they were poorly designed from the start and needed to be replaced anyway. With that being said, I did not take any care into seeing what this would affect. Echelon still works perfectly fine for me, without a single noticeable error introduced by this change, so I am going to push it to main.